### PR TITLE
Datamatrix & I25 extras

### DIFF
--- a/include/barcodes/datamatrix.php
+++ b/include/barcodes/datamatrix.php
@@ -238,6 +238,7 @@ class Datamatrix {
 	 * @param $code (string) Code to represent using Datamatrix.
      * @param $encoding (int) One of the defined constants above representing an encoding to use throughout the entire code
 	 * @public
+     * @throws LogicException if $code isn't encodable by $encoding
 	 */
 	public function __construct($code, $encoding = null) {
 		$barcode_array = array();
@@ -563,8 +564,6 @@ class Datamatrix {
 	 * @param $mode (int) current encoding mode
 	 * @return int encoding mode
 	 * @protected
-     *
-     * @throws Exception if the forced encoding can't encode the data
 	 */
 	protected function lookAheadTest($data, $pos, $mode) {
         if ($this->forcedEncoding !== null) {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -15509,7 +15509,7 @@ class TCPDF {
 	 * @since 4.5.037 (2009-04-07)
 	 * @public
 	 */
-	public function write2DBarcode($code, $type, $x='', $y='', $w='', $h='', $style='', $align='', $distort=false) {
+	public function write2DBarcode($code, $type, $x='', $y='', $w='', $h='', $style='', $align='', $distort=false, $extra=null) {
 		if (TCPDF_STATIC::empty_string(trim($code))) {
 			return;
 		}
@@ -15517,7 +15517,7 @@ class TCPDF {
 		// save current graphic settings
 		$gvars = $this->getGraphicVars();
 		// create new barcode object
-		$barcodeobj = new TCPDF2DBarcode($code, $type);
+		$barcodeobj = new TCPDF2DBarcode($code, $type, $extra);
 		$arrcode = $barcodeobj->getBarcodeArray();
 		if (($arrcode === false) OR empty($arrcode) OR !isset($arrcode['num_rows']) OR ($arrcode['num_rows'] == 0) OR !isset($arrcode['num_cols']) OR ($arrcode['num_cols'] == 0)) {
 			$this->Error('Error in 2D barcode string');

--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -69,6 +69,7 @@ class TCPDFBarcode {
 	 * @param $code (string) code to print
  	 * @param $type (string) type of barcode: <ul><li>C39 : CODE 39 - ANSI MH10.8M-1983 - USD-3 - 3 of 9.</li><li>C39+ : CODE 39 with checksum</li><li>C39E : CODE 39 EXTENDED</li><li>C39E+ : CODE 39 EXTENDED + CHECKSUM</li><li>C93 : CODE 93 - USS-93</li><li>S25 : Standard 2 of 5</li><li>S25+ : Standard 2 of 5 + CHECKSUM</li><li>I25 : Interleaved 2 of 5</li><li>I25+ : Interleaved 2 of 5 + CHECKSUM</li><li>C128 : CODE 128</li><li>C128A : CODE 128 A</li><li>C128B : CODE 128 B</li><li>C128C : CODE 128 C</li><li>EAN2 : 2-Digits UPC-Based Extension</li><li>EAN5 : 5-Digits UPC-Based Extension</li><li>EAN8 : EAN 8</li><li>EAN13 : EAN 13</li><li>UPCA : UPC-A</li><li>UPCE : UPC-E</li><li>MSI : MSI (Variation of Plessey code)</li><li>MSI+ : MSI + CHECKSUM (modulo 11)</li><li>POSTNET : POSTNET</li><li>PLANET : PLANET</li><li>RMS4CC : RMS4CC (Royal Mail 4-state Customer Code) - CBC (Customer Bar Code)</li><li>KIX : KIX (Klant index - Customer index)</li><li>IMB: Intelligent Mail Barcode - Onecode - USPS-B-3200</li><li>CODABAR : CODABAR</li><li>CODE11 : CODE 11</li><li>PHARMA : PHARMACODE</li><li>PHARMA2T : PHARMACODE TWO-TRACKS</li></ul>
  	 * @public
+     * @throws InvalidArgumentException if $code isn't a string
 	 */
 	public function __construct($code, $type) {
         if (!is_string($code)) {

--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -71,7 +71,11 @@ class TCPDFBarcode {
  	 * @public
 	 */
 	public function __construct($code, $type) {
-		$this->setBarcode($code, $type);
+        if (!is_string($code)) {
+            throw new InvalidArgumentException('$code must be a string!');
+        }
+
+        $this->setBarcode($code, $type);
 	}
 
 	/**
@@ -748,6 +752,7 @@ class TCPDFBarcode {
 		if($r > 0) {
 			$r = (10 - $r);
 		}
+
 		return $r;
 	}
 
@@ -892,6 +897,9 @@ class TCPDFBarcode {
 	 * @protected
 	 */
 	protected function barcode_i25($code, $checksum=false) {
+        //valid I25 must be pairs of digits, so prepend a 0 if its invalid. check for odd if checksum = false otherwise check for even since the checksum counts as a digit
+        $code = strlen($code) % 2 !== (int)$checksum ? "0" . $code : $code;
+
 		$chr['0'] = '11221';
 		$chr['1'] = '21112';
 		$chr['2'] = '12112';
@@ -2171,7 +2179,7 @@ class TCPDFBarcode {
 
 	/**
 	 * IMB - Intelligent Mail Barcode - Onecode - USPS-B-3200
-	 * 
+	 *
 	 * @param $code (string) pre-formatted IMB barcode (65 chars "FADT")
 	 * @return array barcode representation.
 	 * @protected

--- a/tcpdf_barcodes_2d.php
+++ b/tcpdf_barcodes_2d.php
@@ -65,6 +65,7 @@ class TCPDF2DBarcode {
 	 * @param $code (string) code to print
  	 * @param $type (string) type of barcode: <ul><li>DATAMATRIX : Datamatrix (ISO/IEC 16022)</li><li>PDF417 : PDF417 (ISO/IEC 15438:2006)</li><li>PDF417,a,e,t,s,f,o0,o1,o2,o3,o4,o5,o6 : PDF417 with parameters: a = aspect ratio (width/height); e = error correction level (0-8); t = total number of macro segments; s = macro segment index (0-99998); f = file ID; o0 = File Name (text); o1 = Segment Count (numeric); o2 = Time Stamp (numeric); o3 = Sender (text); o4 = Addressee (text); o5 = File Size (numeric); o6 = Checksum (numeric). NOTES: Parameters t, s and f are required for a Macro Control Block, all other parametrs are optional. To use a comma character ',' on text options, replace it with the character 255: "\xff".</li><li>QRCODE : QRcode Low error correction</li><li>QRCODE,L : QRcode Low error correction</li><li>QRCODE,M : QRcode Medium error correction</li><li>QRCODE,Q : QRcode Better error correction</li><li>QRCODE,H : QR-CODE Best error correction</li><li>RAW: raw mode - comma-separad list of array rows</li><li>RAW2: raw mode - array rows are surrounded by square parenthesis.</li><li>TEST : Test matrix</li></ul>
      * @param $extra (mixed) extra data to pass to barcode classes, currently only used by Datamatrix
+     * @throws InvalidArgumentException if $code isn't a string
 	 */
 	public function __construct($code, $type, $extra = null) {
         if(!is_string($code)){

--- a/tcpdf_barcodes_2d.php
+++ b/tcpdf_barcodes_2d.php
@@ -67,6 +67,9 @@ class TCPDF2DBarcode {
      * @param $extra (mixed) extra data to pass to barcode classes, currently only used by Datamatrix
 	 */
 	public function __construct($code, $type, $extra = null) {
+        if(!is_string($code)){
+            throw new InvalidArgumentException('$code must be a string!');
+        }
 		$this->setBarcode($code, $type, $extra);
 	}
 

--- a/tcpdf_barcodes_2d.php
+++ b/tcpdf_barcodes_2d.php
@@ -64,9 +64,10 @@ class TCPDF2DBarcode {
 	 * <li>$arrcode['bcode'][$r][$c] value of the cell is $r row and $c column (0 = transparent, 1 = black)</li></ul>
 	 * @param $code (string) code to print
  	 * @param $type (string) type of barcode: <ul><li>DATAMATRIX : Datamatrix (ISO/IEC 16022)</li><li>PDF417 : PDF417 (ISO/IEC 15438:2006)</li><li>PDF417,a,e,t,s,f,o0,o1,o2,o3,o4,o5,o6 : PDF417 with parameters: a = aspect ratio (width/height); e = error correction level (0-8); t = total number of macro segments; s = macro segment index (0-99998); f = file ID; o0 = File Name (text); o1 = Segment Count (numeric); o2 = Time Stamp (numeric); o3 = Sender (text); o4 = Addressee (text); o5 = File Size (numeric); o6 = Checksum (numeric). NOTES: Parameters t, s and f are required for a Macro Control Block, all other parametrs are optional. To use a comma character ',' on text options, replace it with the character 255: "\xff".</li><li>QRCODE : QRcode Low error correction</li><li>QRCODE,L : QRcode Low error correction</li><li>QRCODE,M : QRcode Medium error correction</li><li>QRCODE,Q : QRcode Better error correction</li><li>QRCODE,H : QR-CODE Best error correction</li><li>RAW: raw mode - comma-separad list of array rows</li><li>RAW2: raw mode - array rows are surrounded by square parenthesis.</li><li>TEST : Test matrix</li></ul>
+     * @param $extra (mixed) extra data to pass to barcode classes, currently only used by Datamatrix
 	 */
-	public function __construct($code, $type) {
-		$this->setBarcode($code, $type);
+	public function __construct($code, $type, $extra = null) {
+		$this->setBarcode($code, $type, $extra);
 	}
 
 	/**
@@ -247,15 +248,16 @@ class TCPDF2DBarcode {
 	 * Set the barcode.
 	 * @param $code (string) code to print
  	 * @param $type (string) type of barcode: <ul><li>DATAMATRIX : Datamatrix (ISO/IEC 16022)</li><li>PDF417 : PDF417 (ISO/IEC 15438:2006)</li><li>PDF417,a,e,t,s,f,o0,o1,o2,o3,o4,o5,o6 : PDF417 with parameters: a = aspect ratio (width/height); e = error correction level (0-8); t = total number of macro segments; s = macro segment index (0-99998); f = file ID; o0 = File Name (text); o1 = Segment Count (numeric); o2 = Time Stamp (numeric); o3 = Sender (text); o4 = Addressee (text); o5 = File Size (numeric); o6 = Checksum (numeric). NOTES: Parameters t, s and f are required for a Macro Control Block, all other parametrs are optional. To use a comma character ',' on text options, replace it with the character 255: "\xff".</li><li>QRCODE : QRcode Low error correction</li><li>QRCODE,L : QRcode Low error correction</li><li>QRCODE,M : QRcode Medium error correction</li><li>QRCODE,Q : QRcode Better error correction</li><li>QRCODE,H : QR-CODE Best error correction</li><li>RAW: raw mode - comma-separad list of array rows</li><li>RAW2: raw mode - array rows are surrounded by square parenthesis.</li><li>TEST : Test matrix</li></ul>
+     * @param $extra (mixed) extra data to pass to barcode classes, currently only used by Datamatrix
  	 * @return array
 	 */
-	public function setBarcode($code, $type) {
+	public function setBarcode($code, $type, $extra = null) {
 		$mode = explode(',', $type);
 		$qrtype = strtoupper($mode[0]);
 		switch ($qrtype) {
 			case 'DATAMATRIX': { // DATAMATRIX (ISO/IEC 16022)
 				require_once(dirname(__FILE__).'/include/barcodes/datamatrix.php');
-				$qrcode = new Datamatrix($code);
+				$qrcode = new Datamatrix($code, $extra);
 				$this->barcode_array = $qrcode->getBarcodeArray();
 				$this->barcode_array['code'] = $code;
 				break;


### PR DESCRIPTION
Adds the ability to force an encoding for datamatrix barcodes as well as adds logic to ensure codes are strings.

Also for I25 and I25+ it adds padding if an incorrect amount of digits are passed